### PR TITLE
Use new 8-digit course numbers for CheeseFork functionality

### DIFF
--- a/src/cheesefork/share-histograms.js
+++ b/src/cheesefork/share-histograms.js
@@ -137,47 +137,19 @@ let cheeseforkShareHistograms = function () {
 			const semesterArray = semesterPretty.split('/', 2);
 			const semester = semesterArray[1] + semesterArray[0];
 			const match = /^\s*\d+\s+(\d+)\s+(.*?)\s*$/.exec(node.textContent);
-			const course = match[1];
+			const courseMatched = match[1];
+			const course = ('0000000' + courseMatched).slice(-8);
 			const name = match[2];
 
 			courses.push({
 				url,
 				semesterPretty,
 				semester,
+				courseMatched,
 				course,
 				name
 			});
 		}
-
-		// Currently, only 0xxx0xxx course numbers are supported. So far,
-		// histograms for other course numbers weren't submitted. Once that
-		// happens, we'll see how to handle it, perhaps by making a proper
-		// transition from 6-digit course numbers to the new 8-digit format.
-		const supportedCourseFormat = courses.every(x => (
-			x.course.length >= 5 &&
-			x.course[x.course.length - 4] === '0' &&
-			x.course.replace(/^0+/, '').length <= 7));
-
-		courses = courses.map(x => {
-			const courseMatched = x.course;
-			let course;
-
-			if (supportedCourseFormat) {
-				const courseWithoutMiddleZero = courseMatched.slice(0, -4) + courseMatched.slice(-3);
-
-				// Handle special cases:
-				// 97030xy -> 9730xy
-				const courseBeforePadding = courseWithoutMiddleZero.replace(/^97030(\d\d)$/, '9730$1');
-
-				course = ('00000' + courseBeforePadding).slice(-6);
-			} else {
-				// Use an underscore to indicate that the course number is of an
-				// unknown format and needs to be fixed manually.
-				course = '_' + courseMatched;
-			}
-
-			return { ...x, courseMatched, course };
-		});
 
 		return courses;
 	}

--- a/src/js/sap.js
+++ b/src/js/sap.js
@@ -2,7 +2,6 @@
 
 (function () {
 	function show_histograms(src, course) {
-		if (course.length === 8) course = course.slice(1, 4) + course.slice(5, 8);
 		const expand = src.getElementsByClassName("TP_expand"),
 			iframe = src.getElementsByTagName("iframe");
 		for (let i = 0; i < expand.length; i++)


### PR DESCRIPTION
BTW the iframe handling can be improved:

The 5 seconds delay feels too long:
https://github.com/TheBooker66/Technion-Plus-Plus/blob/091481c5e098d86ecd4e4fbbd9982b5c88a9c3c6/src/js/sap.js#L68
I'd change it to trying every 200 milliseconds or so.

And the iframes don't get re-injected when switching to another tab in SAP and back.